### PR TITLE
Add View only wallet, add key image import / export functions

### DIFF
--- a/src-electron/main-process/modules/wallet-rpc.js
+++ b/src-electron/main-process/modules/wallet-rpc.js
@@ -229,9 +229,11 @@ export class WalletRPC {
             case "get_private_keys":
                 this.getPrivateKeys(params.password)
                 break
-
             case "export_key_images":
-                this.exportKeyImages()
+                this.exportKeyImages(params.path)
+                break
+            case "import_key_images":
+                this.importKeyImages(params.path)
                 break
 
             default:
@@ -964,6 +966,36 @@ export class WalletRPC {
             })
         })
     }
+
+    importKeyImages(filepath=null) {
+
+        if(filepath == null)
+            filepath = path.join(this.data_dir, "gui", "key_image_export.json")
+
+        fs.readFile(filepath, "utf8", (err, data) => {
+	    if(err) {
+                this.sendGateway("show_notification", {type: "negative", message: "Error importing key images: file read error", timeout: 2000})
+                return
+            }
+            let key_images = {};
+            try {
+                key_images = JSON.parse(data)
+            } catch (e) {
+                this.sendGateway("show_notification", {type: "negative", message: "Error importing key images: parse error", timeout: 2000})
+                return
+            }
+
+            this.sendRPC("import_key_images", key_images).then((data) => {
+                if(data.hasOwnProperty("error") || !data.hasOwnProperty("result")) {
+                    this.sendGateway("show_notification", {type: "negative", message: "Error importing images", timeout: 2000})
+                    return
+                }
+
+                this.sendGateway("show_notification", {message: "Key images imported", timeout: 2000})
+            })
+        })
+    }
+
 
     listWallets(legacy=false) {
 

--- a/src-electron/main-process/modules/wallet-rpc.js
+++ b/src-electron/main-process/modules/wallet-rpc.js
@@ -185,6 +185,10 @@ export class WalletRPC {
                 this.restoreWallet(params.name, params.password, params.seed, params.refresh_start_height)
                 break
 
+            case "restore_view_wallet":
+                this.restoreViewWallet(params.name, params.password, params.address, params.viewkey, params.refresh_start_height)
+                break
+
             case "import_wallet":
                 this.importWallet(params.name, params.password, params.path)
                 break
@@ -299,6 +303,34 @@ export class WalletRPC {
             this.finalizeNewWallet(filename)
 
             //});
+
+        });
+    }
+
+    restoreViewWallet(filename, password, address, viewkey, refresh_start_height=0) {
+
+        if(!Number.isInteger(refresh_start_height)) {
+            refresh_start_height = 0
+        }
+
+        this.sendRPC("restore_view_wallet", {
+            filename,
+            password,
+            address,
+            viewkey,
+            refresh_start_height
+        }).then((data) => {
+            if(data.hasOwnProperty("error")) {
+                this.sendGateway("set_wallet_error", {status:data.error})
+                return
+            }
+
+            // store hash of the password so we can check against it later when requesting private keys, or for sending txs
+            this.wallet_state.password_hash = crypto.pbkdf2Sync(password, this.auth[2], 1000, 64, "sha512").toString("hex")
+            this.wallet_state.name = filename
+            this.wallet_state.open = true
+
+            this.finalizeNewWallet(filename)
 
         });
     }

--- a/src/gateway/gateway.js
+++ b/src/gateway/gateway.js
@@ -1,5 +1,5 @@
 import { ipcRenderer } from "electron"
-import { Dialog, Loading } from "quasar"
+import { Notify, Dialog, Loading } from "quasar"
 import { SCEE } from "./SCEE-Node";
 import * as WebSocket from "ws"
 
@@ -116,6 +116,15 @@ export class Gateway {
 
             case "settings_changed_reboot":
                 this.confirmClose("Changes require restart. Would you like to exit now?")
+                break
+
+            case "show_notification":
+                let notification = {
+                    type: "positive",
+                    timeout: 1000,
+                    message: ""
+                }
+                Notify.create(Object.assign(notification, decrypted_data.data))
                 break
 
         }

--- a/src/layouts/wallet-select/main.vue
+++ b/src/layouts/wallet-select/main.vue
@@ -51,37 +51,23 @@ export default {
             switch(this.$route.name) {
                 case "wallet-create":
                     return "Create new wallet"
-                    break;
                 case "wallet-restore":
                     return "Restore wallet from seed"
-                    break;
                 case "wallet-import":
                     return "Import wallet from file"
-                    break;
+                case "wallet-import-view-only":
+                    return "Restore view-only wallet"
                 case "wallet-import-legacy":
                     return "Import wallet from legacy gui"
-                    break;
                 case "wallet-created":
                     return "Wallet created/restored"
-                    break;
 
                 default:
                 case "wallet-select":
                     return "Ryo"
-                    break;
             }
         }
     },
-    /*
-    watch: {
-        "$route": {
-            deep: true,
-            handler: function (route) {
-                this.page_title = route.name
-            }
-        }
-    },
-    */
     methods: {
         cancel() {
             this.$router.replace({ path: "/wallet-select" });

--- a/src/pages/wallet-select/created.vue
+++ b/src/pages/wallet-select/created.vue
@@ -4,16 +4,20 @@
     <AddressHeader :address="info.address" :header="info.name" :subheader="info.address" />
 
 
-    <h6 class="q-mb-xs">Seed words</h6>
-    <p>{{ secret.mnemonic }}</p>
+    <template v-if="secret.mnemonic">
+        <h6 class="q-mb-xs">Seed words</h6>
+        <p>{{ secret.mnemonic }}</p>
+    </template>
 
     <template v-if="secret.view_key != secret.spend_key">
         <h6 class="q-mb-xs">View key</h6>
         <p>{{ secret.view_key }}</p>
     </template>
 
-    <h6 class="q-mb-xs">Spend key</h6>
-    <p>{{ secret.spend_key }}</p>
+    <template v-if="secret.spend_key != '0000000000000000000000000000000000000000000000000000000000000000'">
+        <h6 class="q-mb-xs">Spend key</h6>
+        <p>{{ secret.spend_key }}</p>
+    </template>
 
     <q-btn class="q-mt-lg" color="primary" @click="open" label="Open wallet" />
 

--- a/src/pages/wallet-select/import-view-only.vue
+++ b/src/pages/wallet-select/import-view-only.vue
@@ -1,0 +1,166 @@
+<template>
+<q-page>
+    <div class="q-mx-md">
+        <q-field class="q-mt-none">
+            <q-input
+                 v-model="wallet.name"
+                 float-label="Wallet name"
+                 @blur="$v.wallet.name.$touch"
+                 :error="$v.wallet.name.$error"
+                 />
+        </q-field>
+
+        <q-field>
+            <q-input
+                 v-model="wallet.address"
+                 float-label="Wallet address"
+                 @blur="$v.wallet.address.$touch"
+                 :error="$v.wallet.address.$error"
+                 />
+        </q-field>
+
+        <q-field>
+            <q-input
+                 v-model="wallet.viewkey"
+                 float-label="Private viewkey"
+                 @blur="$v.wallet.viewkey.$touch"
+                 :error="$v.wallet.viewkey.$error"
+                 />
+        </q-field>
+
+        <q-field>
+            <q-input v-model="wallet.refresh_start_height" type="number"
+                     min="0" float-label="Restore height"
+                     @blur="$v.wallet.refresh_start_height.$touch"
+                     :error="$v.wallet.refresh_start_height.$error"
+                     />
+        </q-field>
+
+        <q-field>
+            <q-input v-model="wallet.password" type="password" float-label="Password" />
+        </q-field>
+
+        <q-field>
+            <q-input v-model="wallet.password_confirm" type="password" float-label="Confirm Password" />
+        </q-field>
+
+        <q-btn color="primary" @click="restore_view_wallet" label="Restore view-only wallet" />
+
+    </div>
+</q-page>
+</template>
+
+<script>
+import { required, numeric } from "vuelidate/lib/validators"
+import { privkey, address } from "src/validators/common"
+import { mapState } from "vuex"
+export default {
+    data () {
+        return {
+            wallet: {
+                name: "",
+                address: "",
+                viewkey: "",
+                refresh_start_height: 0,
+                password: "",
+                password_confirm: ""
+            },
+        }
+    },
+    computed: mapState({
+        status: state => state.gateway.wallet.status,
+    }),
+    watch: {
+        status: {
+            handler(val, old){
+                if(val.code == old.code) return
+                switch(this.status.code) {
+                    case 1:
+                        break;
+                    case 0:
+                        this.$q.loading.hide()
+                        this.$router.replace({ path: "/wallet-select/created" });
+                        break;
+                    default:
+                        this.$q.loading.hide()
+                        this.$q.notify({
+                            type: "negative",
+                            timeout: 1000,
+                            message: this.status.message
+                        })
+                        break;
+                }
+            },
+            deep: true
+        }
+    },
+    validations: {
+        wallet: {
+            name: { required },
+            address: { required, address },
+            viewkey: { required, privkey },
+            refresh_start_height: { numeric }
+        }
+    },
+    methods: {
+        restore_view_wallet() {
+            this.$v.wallet.$touch()
+
+            if (this.$v.wallet.name.$error) {
+                this.$q.notify({
+                    type: "negative",
+                    timeout: 1000,
+                    message: "Enter a wallet name"
+                })
+                return
+            }
+            if (this.$v.wallet.address.$error) {
+                this.$q.notify({
+                    type: "negative",
+                    timeout: 1000,
+                    message: "Invalid public address"
+                })
+                return
+            }
+
+            if (this.$v.wallet.viewkey.$error) {
+                this.$q.notify({
+                    type: "negative",
+                    timeout: 1000,
+                    message: "Invalid private viewkey"
+                })
+                return
+            }
+
+            if (this.$v.wallet.refresh_start_height.$error) {
+                this.$q.notify({
+                    type: "negative",
+                    timeout: 1000,
+                    message: "Invalid restore height"
+                })
+                return
+            }
+            if(this.wallet.password != this.wallet.password_confirm) {
+                this.$q.notify({
+                    type: "negative",
+                    timeout: 1000,
+                    message: "Passwords do not match"
+                })
+                return
+            }
+
+            this.$q.loading.show({
+                delay: 0
+            })
+
+            this.$gateway.send("wallet", "restore_view_wallet", this.wallet);
+        },
+        cancel() {
+            this.$router.replace({ path: "/wallet-select" });
+        }
+    }
+}
+</script>
+
+<style>
+</style>

--- a/src/pages/wallet-select/index.vue
+++ b/src/pages/wallet-select/index.vue
@@ -23,6 +23,10 @@
             <!--<q-item-side avatar="statics/guy-avatar.png" />-->
             <q-item-main label="Restore wallet from seed" />
         </q-item>
+        <q-item @click.native="restoreViewWallet()">
+            <!--<q-item-side avatar="statics/guy-avatar.png" />-->
+            <q-item-main label="Restore view-only wallet" />
+        </q-item>
         <q-item @click.native="importWallet()">
             <!--<q-item-side avatar="statics/guy-avatar.png" />-->
             <q-item-main label="Import wallet from file" />
@@ -81,6 +85,9 @@ export default {
         },
         restoreWallet() {
             this.$router.replace({ path: "wallet-select/restore" });
+        },
+        restoreViewWallet() {
+            this.$router.replace({ path: "wallet-select/import-view-only" });
         },
         importWallet() {
             this.$router.replace({ path: "wallet-select/import" });

--- a/src/pages/wallet/wallet.vue
+++ b/src/pages/wallet/wallet.vue
@@ -31,12 +31,12 @@
             <q-btn icon="more_vert" label="" size="md" flat>
                 <q-popover>
                     <q-list separator link>
-                        <q-item v-close-overlay @click.native="export_modal_show = true">
+                        <q-item v-close-overlay @click.native="key_image_modal_show = true; key_image_import_export = 'Export'">
                             <q-item-main>
                                 <q-item-tile label>Export Key Images</q-item-tile>
                             </q-item-main>
                         </q-item>
-                        <q-item v-close-overlay @click.native="importKeyImages">
+                        <q-item v-close-overlay @click.native="key_image_modal_show = true; key_image_import_export = 'Import'">
                             <q-item-main>
                                 <q-item-tile label>Import Key Images</q-item-tile>
                             </q-item-main>
@@ -112,11 +112,11 @@
         </div>
     </q-modal>
 
-    <q-modal minimized v-model="export_modal_show">
+    <q-modal minimized v-model="key_image_modal_show">
         <div class="q-ma-md">
 
-            <h4 class="q-mt-lg q-mb-md">Export key images</h4>
-            <p>Select file location for export.</p>
+            <h4 class="q-mt-lg q-mb-md">{{this.key_image_import_export}} key images</h4>
+            <p>Select file location for key image import/export.</p>
 
             <q-field>
                 <div class="row gutter-sm">
@@ -132,15 +132,15 @@
 
             <div class="q-mt-xl text-right">
                 <q-btn
-                     flat class="q-mr-sm"
-                     @click="export_modal_show = false"
-                     label="Close"
+                    flat class="q-mr-sm"
+                    @click="key_image_modal_show = false"
+                    label="Close"
                      />
                 <q-btn
-                     color="primary"
-                     @click="exportKeyImages()"
-                     label="Export"
-                     />
+                    color="primary"
+                    @click="doKeyImages()"
+                    :label="this.key_image_import_export"
+                    />
             </div>
         </div>
     </q-modal>
@@ -168,7 +168,8 @@ export default {
             rescan_modal_show: false,
             rescan_type: "full",
             key_image_path: null,
-            export_modal_show: false,
+            key_image_modal_show: false,
+            key_image_import_export: "Export",
         }
     },
     watch: {
@@ -248,9 +249,12 @@ export default {
         setKeyImagePath (file) {
             this.key_image_path = file.target.files[0].path
         },
-        exportKeyImages () {
-            this.export_modal_show = false
-            this.$gateway.send("wallet", "export_key_images", {path: this.key_image_path})
+        doKeyImages () {
+            this.key_image_modal_show = false
+            if(this.key_image_import_export == "Export")
+                this.$gateway.send("wallet", "export_key_images", {path: this.key_image_path})
+            else if(this.key_image_import_export == "Import")
+                this.$gateway.send("wallet", "import_key_images", {path: this.key_image_path})
         }
     },
     components: {

--- a/src/pages/wallet/wallet.vue
+++ b/src/pages/wallet/wallet.vue
@@ -22,13 +22,31 @@
 
         <div class="infoBox q-pt-md">
             <q-btn
-                 :disable="!is_ready"
-                 flat @click="getPrivateKeys()">Show seed words</q-btn>
+                :disable="!is_ready"
+                flat @click="getPrivateKeys()">Show seed words</q-btn>
             <q-btn
-                 :disable="!is_ready"
-                 flat @click="rescan_modal_show = true">Rescan Wallet</q-btn>
-        </div>
+                :disable="!is_ready"
+                flat @click="rescan_modal_show = true">Rescan Wallet</q-btn>
 
+            <q-btn icon="more_vert" label="" size="md" flat>
+                <q-popover>
+                    <q-list separator link>
+                        <q-item v-close-overlay @click.native="export_modal_show = true">
+                            <q-item-main>
+                                <q-item-tile label>Export Key Images</q-item-tile>
+                            </q-item-main>
+                        </q-item>
+                        <q-item v-close-overlay @click.native="importKeyImages">
+                            <q-item-main>
+                                <q-item-tile label>Import Key Images</q-item-tile>
+                            </q-item-main>
+                        </q-item>
+                    </q-list>
+                </q-popover>
+
+            </q-btn>
+
+        </div>
     </div>
 
 
@@ -58,10 +76,10 @@
             <p>{{ secret.spend_key }}</p>
 
             <q-btn
-                 color="primary"
-                 @click="private_keys_modal_show = false"
-                 label="Close"
-                 />
+                color="primary"
+                @click="private_keys_modal_show = false"
+                label="Close"
+                />
         </div>
     </q-modal>
 
@@ -81,14 +99,47 @@
 
             <div class="q-mt-xl text-right">
                 <q-btn
+                    flat class="q-mr-sm"
+                    @click="rescan_modal_show = false"
+                    label="Close"
+                    />
+                <q-btn
+                    color="primary"
+                    @click="rescanWallet()"
+                    label="Rescan"
+                    />
+            </div>
+        </div>
+    </q-modal>
+
+    <q-modal minimized v-model="export_modal_show">
+        <div class="q-ma-md">
+
+            <h4 class="q-mt-lg q-mb-md">Export key images</h4>
+            <p>Select file location for export.</p>
+
+            <q-field>
+                <div class="row gutter-sm">
+                    <div class="col-8">
+                        <q-input v-model="key_image_path" stack-label="Key image output directory" disable />
+                        <input type="file" webkitdirectory directory id="keyImagePath" v-on:change="setKeyImagePath" ref="fileInput" hidden />
+                    </div>
+                    <div class="col-4">
+                        <q-btn v-on:click="selectFile">Browse</q-btn>
+                    </div>
+                </div>
+            </q-field>
+
+            <div class="q-mt-xl text-right">
+                <q-btn
                      flat class="q-mr-sm"
-                     @click="rescan_modal_show = false"
+                     @click="export_modal_show = false"
                      label="Close"
                      />
                 <q-btn
                      color="primary"
-                     @click="rescanWallet()"
-                     label="Rescan"
+                     @click="exportKeyImages()"
+                     label="Export"
                      />
             </div>
         </div>
@@ -115,7 +166,9 @@ export default {
             spinner: false,
             private_keys_modal_show: false,
             rescan_modal_show: false,
-            rescan_type: "full"
+            rescan_type: "full",
+            key_image_path: null,
+            export_modal_show: false,
         }
     },
     watch: {
@@ -123,7 +176,6 @@ export default {
             handler(val, old) {
                 if(val.view_key == old.view_key) return
                 this.spinner = false
-                console.log(this.secret.view_key)
                 switch(this.secret.view_key) {
                     case "":
                         break
@@ -189,6 +241,16 @@ export default {
             } else {
                 this.$gateway.send("wallet", "rescan_spent")
             }
+        },
+        selectFile () {
+            this.$refs.fileInput.click()
+        },
+        setKeyImagePath (file) {
+            this.key_image_path = file.target.files[0].path
+        },
+        exportKeyImages () {
+            this.export_modal_show = false
+            this.$gateway.send("wallet", "export_key_images", {path: this.key_image_path})
         }
     },
     components: {

--- a/src/router/routes.js
+++ b/src/router/routes.js
@@ -50,6 +50,12 @@ export default [
                     import ("pages/wallet-select/restore")
             },
             {
+                path: "import-view-only",
+                name: "wallet-import-view-only",
+                component: () =>
+                    import ("pages/wallet-select/import-view-only")
+            },
+            {
                 path: "import",
                 name: "wallet-import",
                 component: () =>

--- a/src/validators/common.js
+++ b/src/validators/common.js
@@ -4,6 +4,10 @@ export const payment_id = (input) => {
     return input.length === 0 || (/^[0-9A-Fa-f]+$/.test(input) && (input.length == 16 || input.length == 64))
 }
 
+export const privkey = (input) => {
+    return input.length === 0 || (/^[0-9A-Fa-f]+$/.test(input) && input.length == 64)
+}
+
 export const address = (input) => {
 
     if(!(/^[0-9A-Za-z]+$/.test(input))) return false


### PR DESCRIPTION
This PR adds a restore view only wallet function to the wallet select screen where user is prompted for private viewkey and public address. We also add a function to import and export key images so view only wallets can be updated with correct balance.